### PR TITLE
Develop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,5 +63,6 @@ const GlobalStyle = createGlobalStyle`
     color: var(--text-color);
     background: var(--background-color);
     text-align: justify;
+    margin: 0;
   }
 `;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { h, Fragment } from 'preact';
 import styled, { createGlobalStyle } from 'styled-components';
 import { Manuscripts } from './Manuscripts';
+import { Container } from './styled/Container';
 
 export const App = () => {
   return (
@@ -14,20 +15,6 @@ export const App = () => {
   );
 };
 
-const Container = styled.div`
-  margin: 0 auto;
-  @media screen and (max-width: 559px) {
-    width: 91vw; 
-    margin-bottom: 1.5em;
-  }
-  @media screen and (min-width: 560px) {
-    width: 85vw;
-  }
-  @media screen and (min-width: 960px) {
-    width: 77vw;
-    max-width: 900px;
-  }
-`;
 const GlobalStyle = createGlobalStyle`
   :root {
     --text-color: hsl(0, 0%, 20%);

--- a/src/Article.tsx
+++ b/src/Article.tsx
@@ -1,6 +1,7 @@
 import { h } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 import { Editor } from './Editor';
+import { useSubmit } from './useSubmit';
 import { articlable, emptyArticle } from './types';
 
 export const Article = (props: {
@@ -10,6 +11,7 @@ export const Article = (props: {
   setModified: () => void,
 }) => {
   const [article, setArticle] = useState<articlable>(emptyArticle);
+  const { submit, isSubmitting } = useSubmit();
 
   useEffect(() => {
     if (props.initArticle) return setArticle(props.initArticle);
@@ -19,7 +21,13 @@ export const Article = (props: {
   }, []);
 
   return (
-    <Editor article={article} isNew={props.isNew} setModified={props.setModified}/>
+    <Editor
+      article={article}
+      isNew={props.isNew}
+      submit={submit}
+      isSubmitting={isSubmitting}
+      setModified={props.setModified}
+    />
   );
 };
 

--- a/src/Article.tsx
+++ b/src/Article.tsx
@@ -51,10 +51,6 @@ export const Article = (props: {
       <Editor
         article={article}
         isNew={props.isNew}
-        handleSubmit={handleSubmit}
-        submit={submit}
-        isSubmitting={isSubmitting}
-        setModified={props.setModified}
         editorRef={editorRef}
       />
     </Fragment>

--- a/src/Article.tsx
+++ b/src/Article.tsx
@@ -1,5 +1,6 @@
 import { h } from 'preact';
 import { useState, useEffect, useRef, Ref } from 'preact/hooks';
+import { v4 as uuidv4 } from 'uuid';
 import { Editor } from './Editor';
 import { useSubmit } from './useSubmit';
 import { articlable, emptyArticle } from './types';
@@ -21,10 +22,22 @@ export const Article = (props: {
       .then(article => setArticle(article));
   }, []);
 
+  const handleSubmit = () => {
+    submit({
+      text: editorRef.current.value(),
+      tags: ['dummyTag1', 'dummyTag2'],
+      uuid: props.isNew ? uuidv4().replace(/-/g, '') : article.uuid,
+      starred: false,
+    }, props.isNew);
+    props.setModified();
+    if (props.isNew) localStorage.setItem('smde_new', '');
+  };
+
   return (
     <Editor
       article={article}
       isNew={props.isNew}
+      handleSubmit={handleSubmit}
       submit={submit}
       isSubmitting={isSubmitting}
       setModified={props.setModified}

--- a/src/Article.tsx
+++ b/src/Article.tsx
@@ -1,6 +1,8 @@
-import { h } from 'preact';
+import { h, Fragment } from 'preact';
 import { useState, useEffect, useRef, Ref } from 'preact/hooks';
 import { v4 as uuidv4 } from 'uuid';
+import dayjs from 'dayjs';
+import { HeaderMenu } from './HeaderMenu';
 import { Editor } from './Editor';
 import { useSubmit } from './useSubmit';
 import { articlable, emptyArticle } from './types';
@@ -34,15 +36,28 @@ export const Article = (props: {
   };
 
   return (
-    <Editor
-      article={article}
-      isNew={props.isNew}
-      handleSubmit={handleSubmit}
-      submit={submit}
-      isSubmitting={isSubmitting}
-      setModified={props.setModified}
-      editorRef={editorRef}
-    />
+    <Fragment>
+      <HeaderMenu
+        createdAt={
+          props.isNew
+            ? dayjs().format('YYYY-MM-DD HH:mm')
+            : article.created_at
+              ? dayjs(article.created_at).format('YYYY-MM-DD HH:mm')
+              : '...'
+          }
+        handleSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+      />
+      <Editor
+        article={article}
+        isNew={props.isNew}
+        handleSubmit={handleSubmit}
+        submit={submit}
+        isSubmitting={isSubmitting}
+        setModified={props.setModified}
+        editorRef={editorRef}
+      />
+    </Fragment>
   );
 };
 

--- a/src/Article.tsx
+++ b/src/Article.tsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect, useRef, Ref } from 'preact/hooks';
 import { Editor } from './Editor';
 import { useSubmit } from './useSubmit';
 import { articlable, emptyArticle } from './types';
@@ -12,6 +12,7 @@ export const Article = (props: {
 }) => {
   const [article, setArticle] = useState<articlable>(emptyArticle);
   const { submit, isSubmitting } = useSubmit();
+  const editorRef: Ref<EasyMDE> = useRef();
 
   useEffect(() => {
     if (props.initArticle) return setArticle(props.initArticle);
@@ -27,6 +28,7 @@ export const Article = (props: {
       submit={submit}
       isSubmitting={isSubmitting}
       setModified={props.setModified}
+      editorRef={editorRef}
     />
   );
 };

--- a/src/Article.tsx
+++ b/src/Article.tsx
@@ -35,6 +35,19 @@ export const Article = (props: {
     if (props.isNew) localStorage.setItem('smde_new', '');
   };
 
+  const handleDelete = () => {
+    fetch(`https://manuscripts.herokuapp.com/api/entries/${props.uuid}`, {
+      method: 'DELETE',
+      headers: { 'Content-type': 'application/json; charset=UTF-8' },
+    })
+      .then(res => res.json())
+      .then(data => console.log(data))
+      .then(_ => props.setModified)
+      // TODO リダイレクトの正しいやり方
+      .then(_ => history.pushState({}, '', location.pathname + '?'))
+      .catch(err => console.error(err));
+  }
+
   return (
     <Fragment>
       <HeaderMenu
@@ -47,6 +60,7 @@ export const Article = (props: {
           }
         handleSubmit={handleSubmit}
         isSubmitting={isSubmitting}
+        handleDelete={handleDelete}
       />
       <Editor
         article={article}

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -14,9 +14,11 @@ import { articlable } from './types';
 export const Editor = (props: {
   article: articlable,
   isNew: boolean,
+  submit: (article: articlable, isNew: boolean) => void,
+  isSubmitting: boolean,
   setModified: () => void,
 }) => {
-  const { submit, isSubmitting } = useSubmit();
+  // const { submit, isSubmitting } = useSubmit();
   const editorRef: Ref<EasyMDE> = useRef();
 
   useEffect(() => {
@@ -29,7 +31,7 @@ export const Editor = (props: {
   }, [props.article]);
 
   const handleSubmit = () => {
-    submit({
+    props.submit({
       text: editorRef.current.value(),
       tags: ['dummyTag1', 'dummyTag2'],
       uuid: props.isNew ? uuidv4().replace(/-/g, '') : props.article.uuid,
@@ -50,7 +52,7 @@ export const Editor = (props: {
               : '...'
           }
         handleSubmit={handleSubmit}
-        isSubmitting={isSubmitting}
+        isSubmitting={props.isSubmitting}
       />
       <EditorWrapper>
         <EasyMDEReact

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -1,12 +1,10 @@
-import { h, Fragment } from 'preact';
-import { useEffect, useRef, Ref } from 'preact/hooks';
+import { h } from 'preact';
+import { useEffect, Ref } from 'preact/hooks';
 import styled from 'styled-components';
 import EasyMDEReact from 'react-simplemde-editor';
 //import EasyMDE from 'easymde';
 import "./css/easymde.css";
 import "./css/codemirror.css";
-import dayjs from 'dayjs';
-import { HeaderMenu } from './HeaderMenu';
 import { articlable } from './types';
 
 export const Editor = (props: {
@@ -28,34 +26,20 @@ export const Editor = (props: {
   }, [props.article]);
 
   return (
-    <Fragment>
-      <HeaderMenu
-        createdAt={
-          props.isNew
-            ? dayjs().format('YYYY-MM-DD HH:mm')
-            : props.article.created_at
-              ? dayjs(props.article.created_at).format('YYYY-MM-DD HH:mm')
-              : '...'
-          }
-        handleSubmit={props.handleSubmit}
-        isSubmitting={props.isSubmitting}
+    <EditorWrapper>
+      <EasyMDEReact
+        getMdeInstance={(instance: EasyMDE) => props.editorRef.current = instance}
+        options={props.isNew
+          ? {
+            autosave: {
+              enabled: true,
+              uniqueId: 'new',
+              delay: 5000,
+            },
+          }: {}
+        }
       />
-      <EditorWrapper>
-        <EasyMDEReact
-          getMdeInstance={(instance: EasyMDE) => props.editorRef.current = instance}
-          options={props.isNew
-            ? {
-                autosave: {
-                  enabled: true,
-                  uniqueId: 'new',
-                  delay: 5000,
-              },
-            }
-            : {}
-          }
-        />
-      </EditorWrapper>
-    </Fragment>
+    </EditorWrapper>
   );
 };
 

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -17,22 +17,20 @@ export const Editor = (props: {
   submit: (article: articlable, isNew: boolean) => void,
   isSubmitting: boolean,
   setModified: () => void,
+  editorRef: Ref<EasyMDE>;
 }) => {
-  // const { submit, isSubmitting } = useSubmit();
-  const editorRef: Ref<EasyMDE> = useRef();
-
   useEffect(() => {
     // @ts-ignore
-    if (!props.isNew) editorRef.current.togglePreview();
+    if (!props.isNew) props.editorRef.current.togglePreview();
   }, []);
 
   useEffect(() => {
-    if (!props.isNew) editorRef.current.value(props.article.text);
+    if (!props.isNew) props.editorRef.current.value(props.article.text);
   }, [props.article]);
 
   const handleSubmit = () => {
     props.submit({
-      text: editorRef.current.value(),
+      text: props.editorRef.current.value(),
       tags: ['dummyTag1', 'dummyTag2'],
       uuid: props.isNew ? uuidv4().replace(/-/g, '') : props.article.uuid,
       starred: false,
@@ -56,7 +54,7 @@ export const Editor = (props: {
       />
       <EditorWrapper>
         <EasyMDEReact
-          getMdeInstance={(instance: EasyMDE) => editorRef.current = instance}
+          getMdeInstance={(instance: EasyMDE) => props.editorRef.current = instance}
           options={props.isNew
             ? {
                 autosave: {

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -30,14 +30,11 @@ export const Editor = (props: {
 
   const handleSubmit = () => {
     submit({
-      article: {
-        text: editorRef.current.value(),
-        tags: ['dummyTag1', 'dummyTag2'],
-        uuid: props.isNew ? uuidv4().replace(/-/g, '') : props.article.uuid,
-        starred: false,
-      },
-      isNew: props.isNew,
-    });
+      text: editorRef.current.value(),
+      tags: ['dummyTag1', 'dummyTag2'],
+      uuid: props.isNew ? uuidv4().replace(/-/g, '') : props.article.uuid,
+      starred: false,
+    }, props.isNew);
     props.setModified();
     if (props.isNew) localStorage.setItem('smde_new', '');
   };

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -6,14 +6,13 @@ import EasyMDEReact from 'react-simplemde-editor';
 import "./css/easymde.css";
 import "./css/codemirror.css";
 import dayjs from 'dayjs';
-import { v4 as uuidv4 } from 'uuid';
 import { HeaderMenu } from './HeaderMenu';
-import { useSubmit } from './useSubmit';
 import { articlable } from './types';
 
 export const Editor = (props: {
   article: articlable,
   isNew: boolean,
+  handleSubmit: () => void;
   submit: (article: articlable, isNew: boolean) => void,
   isSubmitting: boolean,
   setModified: () => void,
@@ -28,17 +27,6 @@ export const Editor = (props: {
     if (!props.isNew) props.editorRef.current.value(props.article.text);
   }, [props.article]);
 
-  const handleSubmit = () => {
-    props.submit({
-      text: props.editorRef.current.value(),
-      tags: ['dummyTag1', 'dummyTag2'],
-      uuid: props.isNew ? uuidv4().replace(/-/g, '') : props.article.uuid,
-      starred: false,
-    }, props.isNew);
-    props.setModified();
-    if (props.isNew) localStorage.setItem('smde_new', '');
-  };
-
   return (
     <Fragment>
       <HeaderMenu
@@ -49,7 +37,7 @@ export const Editor = (props: {
               ? dayjs(props.article.created_at).format('YYYY-MM-DD HH:mm')
               : '...'
           }
-        handleSubmit={handleSubmit}
+        handleSubmit={props.handleSubmit}
         isSubmitting={props.isSubmitting}
       />
       <EditorWrapper>

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -10,10 +10,6 @@ import { articlable } from './types';
 export const Editor = (props: {
   article: articlable,
   isNew: boolean,
-  handleSubmit: () => void;
-  submit: (article: articlable, isNew: boolean) => void,
-  isSubmitting: boolean,
-  setModified: () => void,
   editorRef: Ref<EasyMDE>;
 }) => {
   useEffect(() => {

--- a/src/HeaderMenu.tsx
+++ b/src/HeaderMenu.tsx
@@ -58,7 +58,10 @@ const HorizontalList = styled.ul`
   align-items: center /* vertical */;
   list-style-type: none;
   background: #4d9abf;
-  padding: 0px;
+  padding: 1em 0;
+  /* reset */
+  margin-block-start: 0;
+  margin-block-end: 0;
 `;
 const DropDown = styled.div`
   display: ${props => props.isOpen ? 'flex' : 'none'};

--- a/src/HeaderMenu.tsx
+++ b/src/HeaderMenu.tsx
@@ -41,11 +41,23 @@ export const HeaderMenu = (props: {
   );
 };
 
+export const TopHeaderMenu = () => {
+  return (
+    <nav>
+      <HorizontalList>
+        <li style="margin-right: auto;"><Button>⚙</Button></li>
+        <li><Button>✏️</Button></li>
+      </HorizontalList>
+    </nav>
+  );
+};
+
 const HorizontalList = styled.ul`
   display: flex;
   justify-content: flex-end;
   align-items: center /* vertical */;
   list-style-type: none;
+  background: #4d9abf;
   padding: 0px;
 `;
 const DropDown = styled.div`

--- a/src/HeaderMenu.tsx
+++ b/src/HeaderMenu.tsx
@@ -7,6 +7,7 @@ export const HeaderMenu = (props: {
   createdAt: string,
   handleSubmit: () => void,
   isSubmitting: boolean,
+  handleDelete: () => void,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -27,7 +28,7 @@ export const HeaderMenu = (props: {
             <div>メニュー1</div>
             <div>メニュー2</div>
             <div>メニュー3</div>
-            <div>❌</div>
+            <Button onClick={props.handleDelete}>❌</Button>
           </DropDown>
         </li>
         <li>

--- a/src/PageList.tsx
+++ b/src/PageList.tsx
@@ -24,4 +24,5 @@ export const PageList = (props: {
 const StyledList = styled.ul`
   list-style: none;
   padding: 0;
+  margin: 0;
 `;

--- a/src/PageList.tsx
+++ b/src/PageList.tsx
@@ -1,7 +1,8 @@
-import { h } from 'preact';
+import { h, Fragment } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 import { Link } from 'wouter';
 import styled from 'styled-components';
+import { TopHeaderMenu } from './HeaderMenu';
 import { PageListItem } from './PageListItem';
 import { articlable } from './types';
 
@@ -9,11 +10,14 @@ export const PageList = (props: {
   articles: articlable[],
 }) => {
   return (
-    <StyledList>
-      {props.articles.map(article => 
-        <PageListItem article={article} />
-      )}
-    </StyledList>
+    <Fragment>
+      <TopHeaderMenu />
+      <StyledList>
+        {props.articles.map(article => 
+          <PageListItem article={article} />
+        )}
+      </StyledList>
+    </Fragment>
   );
 };
 

--- a/src/styled/Container.tsx
+++ b/src/styled/Container.tsx
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  margin: 0 auto;
+  @media screen and (max-width: 559px) {
+    width: 91vw; 
+    margin-bottom: 1.5em;
+  }
+  @media screen and (min-width: 560px) {
+    width: 85vw;
+  }
+  @media screen and (min-width: 960px) {
+    width: 77vw;
+    max-width: 900px;
+  }
+`;

--- a/src/useSubmit.ts
+++ b/src/useSubmit.ts
@@ -4,14 +4,11 @@ import { articlable } from './types';
 export const useSubmit = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const submit = (params: {
-    article: articlable,
-    isNew: boolean,
-  }) => {
+  const submit = (article: articlable, isNew: boolean) => {
     setIsSubmitting(true);
-    fetch(`https://manuscripts.herokuapp.com/api/entries/${params.article.uuid}`, {
-      method: params.isNew ? 'POST' : 'PUT',
-      body: JSON.stringify(params.article),
+    fetch(`https://manuscripts.herokuapp.com/api/entries/${article.uuid}`, {
+      method: isNew ? 'POST' : 'PUT',
+      body: JSON.stringify(article),
       headers: { 'Content-type': 'application/json; charset=UTF-8' },
     })
       .then(res => res.json())


### PR DESCRIPTION
## feat

- feat: 削除機能のプロトタイプ
- feat: トップページのヘッダーメニュー 同じ装飾のものはファイル内からexportすればいい（同一コンポーネント内で分岐するより筋がいい）
- feat: デフォルトの余白を削除

## refactor

- refactor: useSubmitのオブジェクト引数をやめる
- refactor: useSubmitのリフトアップ Editor->Article
- refactor: editorRefのリフトアップ
- refactor: handleSubmitのリフトアップ
- refactor: ヘッダーメニューのリフトアップ
- refactor: 不要になったEditorのpropsを削除
- refactor: Containerを切り出し styledフォルダを作成